### PR TITLE
start a new log when "New [type]" is selected from drawer while editing

### DIFF
--- a/src/components/EditLog.vue
+++ b/src/components/EditLog.vue
@@ -458,10 +458,19 @@ export default {
 
       }
     },
-    type() {
-      console.log(`TYPE HAS CHANGED TO ${this.type}`)
-      this.updateCurrentLog('type', this.type);
-    },
+
+    // This catches route changes from `/log/edit` to `/log/edit` and creates
+    // a new log by the same procedure as in the `created()` hook.
+    '$route'(to, from) {
+      if (typeof to.params.index === 'number') {
+        // If a log index is provided in query params, set it as current log
+        this.$store.commit('setCurrentLogIndex', this.$route.params.index)
+      } else {
+        // Create a new log.  The 'type' prop is set based on the 'type' param in the local route
+        this.$store.dispatch('initializeLog', this.type);
+        console.log(`LOG IS RECEIVING TYPE AS ${this.type}`);
+      }
+    }
   },
 };
 


### PR DESCRIPTION
This resolves #41 with a slightly different approach, starting a whole new log instead of changing the type of the current log.

See https://github.com/farmOS/farmOS-client/issues/41#issuecomment-461488192 for more details.